### PR TITLE
Find and fix two sv bugs

### DIFF
--- a/src/mci/rtl/mci_lcc_st_trans.sv
+++ b/src/mci/rtl/mci_lcc_st_trans.sv
@@ -190,7 +190,7 @@ always_comb begin: state_branch
             end
             else if (ss_dbg_manuf_enable_i) begin
                 mci_trans_st_next = TRANSLATOR_MANUF_DEBUG;
-                security_state_comb = '{device_lifecycle: DEVICE_MANUFACTURING, debug_locked: 1'b1}; 
+                security_state_comb = '{device_lifecycle: DEVICE_MANUFACTURING, debug_locked: 1'b0}; 
             end
             else begin
                 mci_trans_st_next = TRANSLATOR_MANUF_NON_DEBUG;
@@ -214,7 +214,7 @@ always_comb begin: state_branch
             end
             else if (CLPTR_PROD_DEBUG_UNLOCK_AND) begin // TODO: Be careful for fault injections
                 mci_trans_st_next = TRANSLATOR_PROD_DEBUG;
-                security_state_comb = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: 1'b1}; 
+                security_state_comb = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: 1'b0}; 
             end
             else begin
                 mci_trans_st_next = TRANSLATOR_PROD_NON_DEBUG;


### PR DESCRIPTION
Correct `debug_locked` assignments to 0 when entering manufacturing and production debug states.

The `debug_locked` signal was incorrectly set to `1'b1` when transitioning into debug-enabled states (TRANSLATOR_MANUF_DEBUG and TRANSLATOR_PROD_DEBUG), which should instead reflect an unlocked state (`1'b0`).

---
<a href="https://cursor.com/background-agent?bcId=bc-e6561105-9df8-43f2-92fb-59bcdda75e4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6561105-9df8-43f2-92fb-59bcdda75e4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

